### PR TITLE
Add light/dark theme toggle and refresh styling

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -8,17 +8,17 @@ const Footer = ({ jp = false }: FooterProps) => {
     : 'Copyright © Jia Sheng Yeap. All rights reserved.';
 
   return (
-    <footer className="mt-20 border-t border-white/10 bg-black/60">
-      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-12 text-sm text-zinc-400 md:flex-row md:items-center md:justify-between lg:px-12">
+    <footer className="mt-20 border-t border-zinc-200/80 bg-white/80 backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-black/60">
+      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-12 text-sm text-zinc-600 transition-colors duration-300 md:flex-row md:items-center md:justify-between lg:px-12 dark:text-zinc-400">
         <div>
-          <p className="text-base font-semibold tracking-wide text-zinc-200">Jia Sheng Yeap</p>
-          <p className="mt-1 max-w-xl text-zinc-400">
+          <p className="text-base font-semibold tracking-wide text-zinc-800 dark:text-zinc-200">Jia Sheng Yeap</p>
+          <p className="mt-1 max-w-xl">
             {jp
               ? 'デジタル製品、ブランド体験、シームレスなUI/UXをデザインし、開発します。'
               : 'Designing and developing immersive digital products, brand stories, and seamless UI/UX experiences.'}
           </p>
         </div>
-        <p className="text-xs uppercase tracking-[0.3em] text-zinc-500">{message}</p>
+        <p className="text-xs uppercase tracking-[0.3em] text-zinc-500 dark:text-zinc-500">{message}</p>
       </div>
     </footer>
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
-import { BsGlobe2 } from 'react-icons/bs';
+import { TbMoon, TbSun, TbWorld } from 'react-icons/tb';
 import HamburgerMenu from 'react-hamburger-menu';
 import AppLink from './common/AppLink';
+import { useTheme } from './common/ThemeProvider';
 
 type HeaderProps = {
   jp?: boolean;
@@ -11,6 +12,8 @@ type HeaderProps = {
 const Header = ({ jp = false, overlay = false }: HeaderProps) => {
   const [open, setOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
 
   useEffect(() => {
     const handleScroll = () => {
@@ -45,17 +48,29 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
     'fixed inset-x-0 top-0 z-50 transition-all duration-300 ease-out',
     isTransparent
       ? 'bg-transparent text-white'
-      : 'border-b border-white/10 bg-black/80 text-zinc-100 backdrop-blur-xl shadow-lg shadow-black/10',
+      : 'border-b border-zinc-200/70 bg-white/80 text-zinc-900 shadow-lg shadow-zinc-900/5 backdrop-blur-xl dark:border-white/10 dark:bg-black/80 dark:text-zinc-100 dark:shadow-black/10',
   ]
     .filter(Boolean)
     .join(' ');
+
+  const ThemeToggle = () => (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className="inline-flex items-center gap-2 rounded-full border border-zinc-300/80 bg-white/70 px-4 py-2 text-sm font-medium text-zinc-700 transition hover:-translate-y-0.5 hover:bg-white dark:border-white/20 dark:bg-white/10 dark:text-zinc-100 dark:hover:bg-white/20"
+      aria-label={jp ? 'テーマを切り替える' : 'Toggle theme'}
+    >
+      {isDark ? <TbSun className="h-4 w-4" /> : <TbMoon className="h-4 w-4" />}
+      <span className="hidden sm:inline">{isDark ? (jp ? 'ライト' : 'Light') : (jp ? 'ダーク' : 'Dark')}</span>
+    </button>
+  );
 
   const NavigationLinks = () => (
     <>
       <li>
         <AppLink
           href={portfolioHref}
-          className="text-sm font-medium tracking-wide text-zinc-200 transition hover:text-white"
+          className="text-sm font-medium tracking-wide text-zinc-700 transition hover:text-zinc-900 dark:text-zinc-200 dark:hover:text-white"
           onClick={closeMenu}
         >
           {portfolioLabel}
@@ -66,7 +81,7 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
           href={resumeHref}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center rounded-full border border-white/20 px-4 py-2 text-sm font-medium transition hover:-translate-y-0.5 hover:bg-white hover:text-black"
+          className="inline-flex items-center rounded-full border border-zinc-300/80 px-4 py-2 text-sm font-medium text-zinc-700 transition hover:-translate-y-0.5 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:text-zinc-100 dark:hover:bg-white dark:hover:text-black"
           onClick={closeMenu}
         >
           {resumeLabel}
@@ -75,12 +90,15 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
       <li>
         <AppLink
           href={languageHref}
-          className="inline-flex items-center gap-2 text-sm font-medium text-zinc-200 transition hover:text-white"
+          className="inline-flex items-center gap-2 text-sm font-medium text-zinc-700 transition hover:text-zinc-900 dark:text-zinc-200 dark:hover:text-white"
           onClick={closeMenu}
         >
-          <BsGlobe2 className="h-4 w-4" />
+          <TbWorld className="h-4 w-4" />
           {languageLabel}
         </AppLink>
+      </li>
+      <li className="mt-2 lg:mt-0">
+        <ThemeToggle />
       </li>
     </>
   );
@@ -117,19 +135,22 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
             width={22}
             height={18}
             strokeWidth={2}
-            color="#f4f4f5"
+            color={isTransparent ? '#f4f4f5' : isDark ? '#f4f4f5' : '#18181b'}
             animationDuration={0.5}
           />
         </button>
       </div>
 
       {open ? (
-        <div className="fixed inset-0 z-40 bg-black/80 backdrop-blur-xl lg:hidden" onClick={closeMenu}>
+        <div className="fixed inset-0 z-40 bg-black/60 backdrop-blur-xl lg:hidden dark:bg-black/80" onClick={closeMenu}>
           <div
-            className="absolute inset-x-6 top-24 rounded-3xl border border-white/10 bg-black/70 p-8 text-left shadow-2xl"
+            className="absolute inset-x-6 top-24 rounded-3xl border border-zinc-200/80 bg-white/90 p-8 text-left shadow-2xl dark:border-white/10 dark:bg-black/70"
             onClick={(event) => event.stopPropagation()}
           >
-            <nav aria-label="Mobile" className="flex flex-col gap-6 text-lg text-zinc-100">
+            <nav
+              aria-label="Mobile"
+              className="flex flex-col gap-6 text-lg text-zinc-800 dark:text-zinc-100"
+            >
               <NavigationLinks />
             </nav>
           </div>

--- a/components/MyLayout.tsx
+++ b/components/MyLayout.tsx
@@ -39,7 +39,7 @@ const Layout = ({
           <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(ldJson) }} />
         ) : null}
       </Head>
-      <div className="relative flex min-h-screen flex-col bg-night text-zinc-100">
+      <div className="relative flex min-h-screen flex-col bg-zinc-50 text-zinc-900 transition-colors duration-300 dark:bg-night dark:text-zinc-100">
         <Header overlay={overlay} jp={jp} />
         <main className={mainClasses}>{children}</main>
         <Footer jp={jp} />

--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -22,20 +22,20 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
   const linksLabel = locale === 'jp' ? '関連リンク' : 'Project Links';
 
   const heroStyle = {
-    background: `radial-gradient(120% 120% at 50% 0%, ${heroBackground} 0%, rgba(8,8,8,0.85) 65%)`,
+    background: `radial-gradient(120% 120% at 50% 0%, ${heroBackground} 0%, rgba(248,250,252,0.92) 65%)`,
   };
 
   return (
     <article className="flex flex-col">
-      <section className="relative isolate overflow-hidden border-b border-white/10" style={heroStyle}>
-        <div className="absolute inset-0 bg-black/65" />
+      <section className="relative isolate overflow-hidden border-b border-zinc-200/70 transition-colors duration-300 dark:border-white/10" style={heroStyle}>
+        <div className="absolute inset-0 bg-white/80 dark:bg-black/65" />
         <div className="relative mx-auto flex max-w-5xl flex-col items-center gap-10 px-6 py-24 text-center lg:px-12">
-          <span className="text-xs uppercase tracking-[0.4em] text-zinc-400">{copy.date}</span>
-          <h1 className="text-3xl font-semibold text-white sm:text-5xl">{copy.title}</h1>
-          <p className="max-w-3xl text-base text-zinc-200 sm:text-lg">{copy.summary}</p>
+          <span className="text-xs uppercase tracking-[0.4em] text-zinc-500">{copy.date}</span>
+          <h1 className="text-3xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-5xl">{copy.title}</h1>
+          <p className="max-w-3xl text-base text-zinc-700 transition-colors duration-300 sm:text-lg dark:text-zinc-200">{copy.summary}</p>
           <div className="relative w-full max-w-3xl">
-            <div className="absolute inset-0 rounded-[3rem] bg-white/10 blur-3xl" />
-            <div className="relative overflow-hidden rounded-[3rem] border border-white/10 bg-black/70 p-12 backdrop-blur-xl">
+            <div className="absolute inset-0 rounded-[3rem] bg-white/70 blur-3xl transition-colors duration-300 dark:bg-white/10" />
+            <div className="relative overflow-hidden rounded-[3rem] border border-zinc-200/70 bg-white/90 p-12 backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-black/70">
               <LazyImage
                 src={project.heroImage}
                 alt={copy.title}
@@ -50,24 +50,24 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
         <div className="flex-1 space-y-8">
           <div>
             <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{overviewTitle}</p>
-            <div className="mt-4 space-y-4 text-base leading-relaxed text-zinc-300">
+            <div className="mt-4 space-y-4 text-base leading-relaxed text-zinc-700 transition-colors duration-300 dark:text-zinc-300">
               {copy.overview.map((paragraph, index) => (
                 <p key={`${project.slug}-overview-${index}`}>{paragraph}</p>
               ))}
             </div>
           </div>
 
-          <div className="grid gap-4 text-sm text-zinc-400 sm:grid-cols-2">
+          <div className="grid gap-4 text-sm text-zinc-600 transition-colors duration-300 sm:grid-cols-2 dark:text-zinc-400">
             {project.designTools ? (
-              <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+              <div className="rounded-2xl border border-zinc-200/70 bg-white/70 p-4 transition-colors duration-300 dark:border-white/10 dark:bg-white/5">
                 <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{designLabel}</p>
-                <p className="mt-2 text-sm text-zinc-200">{project.designTools}</p>
+                <p className="mt-2 text-sm text-zinc-800 transition-colors duration-300 dark:text-zinc-200">{project.designTools}</p>
               </div>
             ) : null}
             {project.developmentTools ? (
-              <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+              <div className="rounded-2xl border border-zinc-200/70 bg-white/70 p-4 transition-colors duration-300 dark:border-white/10 dark:bg-white/5">
                 <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{developmentLabel}</p>
-                <p className="mt-2 text-sm text-zinc-200">{project.developmentTools}</p>
+                <p className="mt-2 text-sm text-zinc-800 transition-colors duration-300 dark:text-zinc-200">{project.developmentTools}</p>
               </div>
             ) : null}
           </div>
@@ -79,7 +79,7 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
                 {project.gallery.map((image, index) => (
                   <div
                     key={`${project.slug}-gallery-${index}`}
-                    className="overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-4"
+                    className="overflow-hidden rounded-3xl border border-zinc-200/70 bg-white/80 p-4 transition-colors duration-300 dark:border-white/10 dark:bg-white/5"
                   >
                     <LazyImage src={image} alt={`${copy.title} detail ${index + 1}`} className="w-full rounded-2xl object-cover" />
                   </div>
@@ -89,11 +89,11 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
           ) : null}
         </div>
 
-        <aside className="w-full max-w-xl space-y-8 rounded-[2.5rem] border border-white/10 bg-black/60 p-8 shadow-2xl backdrop-blur-xl">
+        <aside className="w-full max-w-xl space-y-8 rounded-[2.5rem] border border-zinc-200/80 bg-white/90 p-8 shadow-2xl backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-black/60">
           <div className="space-y-2">
             <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{roleLabel}</p>
-            <p className="text-lg font-semibold text-white">{copy.role}</p>
-            <p className="text-sm leading-relaxed text-zinc-300">{copy.roleDescription}</p>
+            <p className="text-lg font-semibold text-zinc-900 transition-colors duration-300 dark:text-white">{copy.role}</p>
+            <p className="text-sm leading-relaxed text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{copy.roleDescription}</p>
           </div>
           <div>
             <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{linksLabel}</p>
@@ -103,7 +103,7 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
                   href={project.links.appStore}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-3 rounded-2xl border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-white hover:text-black"
+                  className="inline-flex items-center gap-3 rounded-2xl border border-zinc-200/70 bg-white/80 px-5 py-3 text-sm font-semibold text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white dark:hover:text-black"
                 >
                   <img src={appStoreIcon} alt="App Store" className="h-5 w-auto" />
                   App Store
@@ -114,7 +114,7 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
                   href={project.links.playStore}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-3 rounded-2xl border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-white hover:text-black"
+                  className="inline-flex items-center gap-3 rounded-2xl border border-zinc-200/70 bg-white/80 px-5 py-3 text-sm font-semibold text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white dark:hover:text-black"
                 >
                   <img src={playStoreIcon} alt="Google Play" className="h-5 w-auto" />
                   Google Play
@@ -125,7 +125,7 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
                   href={project.links.website.href}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-3 rounded-2xl border border-white/20 bg-white/10 px-5 py-3 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-white hover:text-black"
+                  className="inline-flex items-center gap-3 rounded-2xl border border-zinc-200/70 bg-white/80 px-5 py-3 text-sm font-semibold text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white dark:hover:text-black"
                 >
                   <span>
                     {locale === 'jp' ? 'ウェブサイト' : 'Visit Website'}
@@ -135,7 +135,7 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
               ) : null}
             </div>
           </div>
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-zinc-300">
+          <div className="rounded-2xl border border-zinc-200/70 bg-white/70 p-6 text-sm text-zinc-600 transition-colors duration-300 dark:border-white/10 dark:bg-white/5 dark:text-zinc-300">
             <p>{copy.date}</p>
           </div>
         </aside>

--- a/components/common/ThemeProvider.tsx
+++ b/components/common/ThemeProvider.tsx
@@ -1,0 +1,69 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+type Theme = 'light' | 'dark';
+
+type ThemeContextValue = {
+  theme: Theme;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'preferred-theme';
+
+const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setTheme] = useState<Theme>('dark');
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const storedTheme = typeof window !== 'undefined' ? (localStorage.getItem(STORAGE_KEY) as Theme | null) : null;
+
+    if (storedTheme === 'light' || storedTheme === 'dark') {
+      setTheme(storedTheme);
+    } else if (window.matchMedia) {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      setTheme(prefersDark ? 'dark' : 'light');
+    }
+
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+
+    const root = document.documentElement;
+    root.classList.toggle('dark', theme === 'dark');
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [mounted, theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((current) => (current === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(() => ({ theme, toggleTheme }), [theme, toggleTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+};
+
+export default ThemeProvider;

--- a/components/home/About.tsx
+++ b/components/home/About.tsx
@@ -55,9 +55,9 @@ const About = ({ jp = false }: { jp?: boolean }) => {
       <div className="mx-auto grid max-w-6xl gap-16 px-6 md:grid-cols-[1.1fr_0.9fr] lg:px-12">
         <Reveal animation="fade-right" className="space-y-8">
           <span className="text-sm uppercase tracking-[0.35em] text-zinc-500">{jp ? '紹介' : 'About'}</span>
-          <h2 className="text-3xl font-semibold text-white sm:text-4xl">{heading}</h2>
+          <h2 className="text-3xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-4xl">{heading}</h2>
           {intro.map((paragraph, index) => (
-            <p key={`intro-${index}`} className="text-base leading-relaxed text-zinc-300 sm:text-lg">
+            <p key={`intro-${index}`} className="text-base leading-relaxed text-zinc-600 transition-colors duration-300 sm:text-lg dark:text-zinc-300">
               {paragraph}
             </p>
           ))}
@@ -68,7 +68,7 @@ const About = ({ jp = false }: { jp?: boolean }) => {
               {focusItems.map((item) => (
                 <span
                   key={item}
-                  className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-zinc-200 shadow-sm"
+                  className="rounded-full border border-zinc-200/70 bg-white/70 px-4 py-2 text-sm font-medium text-zinc-700 shadow-sm transition-colors duration-300 dark:border-white/10 dark:bg-white/5 dark:text-zinc-200"
                 >
                   {item}
                 </span>
@@ -78,9 +78,9 @@ const About = ({ jp = false }: { jp?: boolean }) => {
         </Reveal>
 
         <div className="relative">
-          <div className="absolute inset-0 rounded-[3rem] border border-white/5 bg-white/5 blur-2xl" />
-          <div className="relative grid gap-6 rounded-[2.5rem] border border-white/10 bg-black/40 p-8 shadow-2xl backdrop-blur-xl">
-            <Reveal animation="zoom-in" className="overflow-hidden rounded-3xl border border-white/10 bg-black/60 p-6">
+          <div className="absolute inset-0 rounded-[3rem] border border-zinc-200/60 bg-white/70 blur-2xl transition-colors duration-300 dark:border-white/5 dark:bg-white/5" />
+          <div className="relative grid gap-6 rounded-[2.5rem] border border-zinc-200/80 bg-white/80 p-8 shadow-2xl backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-black/40">
+            <Reveal animation="zoom-in" className="overflow-hidden rounded-3xl border border-zinc-200/60 bg-white/70 p-6 transition-colors duration-300 dark:border-white/10 dark:bg-black/60">
               <LazyImage
                 src="/gif/PhoneGIF.gif"
                 alt="Animated interface mockups"
@@ -93,10 +93,10 @@ const About = ({ jp = false }: { jp?: boolean }) => {
                 <Reveal
                   key={card.title}
                   animation="fade-up"
-                  className="rounded-2xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:bg-white/10"
+                  className="rounded-2xl border border-zinc-200/70 bg-white/70 p-6 transition hover:-translate-y-1 hover:bg-white dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
                 >
-                  <h3 className="text-lg font-semibold text-white">{card.title}</h3>
-                  <p className="mt-2 text-sm leading-relaxed text-zinc-300">{card.description}</p>
+                  <h3 className="text-lg font-semibold text-zinc-900 transition-colors duration-300 dark:text-white">{card.title}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{card.description}</p>
                 </Reveal>
               ))}
             </div>

--- a/components/home/Contact.tsx
+++ b/components/home/Contact.tsx
@@ -1,4 +1,4 @@
-import { BsLinkedin } from 'react-icons/bs';
+import { TbBrandLinkedin } from 'react-icons/tb';
 import Reveal from '../common/Reveal';
 import AppLink from '../common/AppLink';
 
@@ -16,17 +16,17 @@ const Contact = ({ icons = false, jp = false }: ContactProps) => {
 
   return (
     <section id="contact" className="relative isolate overflow-hidden py-24">
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-72 bg-gradient-to-b from-sky-500/10 via-transparent to-transparent blur-3xl" />
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-72 bg-gradient-to-b from-sky-400/10 via-transparent to-transparent blur-3xl" />
       <div className="mx-auto max-w-4xl px-6 lg:px-12">
         <Reveal
           delay={200}
-          className="relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-gradient-to-br from-white/10 via-black/60 to-black/80 p-12 text-center shadow-2xl backdrop-blur-xl"
+          className="relative overflow-hidden rounded-[2.5rem] border border-zinc-200/70 bg-gradient-to-br from-white via-zinc-100 to-zinc-200 p-12 text-center shadow-2xl backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-gradient-to-br dark:from-white/10 dark:via-black/60 dark:to-black/80"
         >
-          <div className="pointer-events-none absolute inset-0 bg-hero-radial opacity-60" />
+          <div className="pointer-events-none absolute inset-0 bg-hero-radial opacity-40 dark:opacity-60" />
           <div className="relative space-y-6">
             <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{jp ? 'コンタクト' : 'Connect'}</p>
-            <h2 className="text-3xl font-semibold text-white sm:text-4xl">{heading}</h2>
-            <p className="mx-auto max-w-2xl text-base text-zinc-300 sm:text-lg">{subheading}</p>
+            <h2 className="text-3xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-4xl">{heading}</h2>
+            <p className="mx-auto max-w-2xl text-base text-zinc-600 transition-colors duration-300 sm:text-lg dark:text-zinc-300">{subheading}</p>
             {icons ? (
               <div className="flex items-center justify-center gap-4">
                 <AppLink
@@ -34,9 +34,9 @@ const Contact = ({ icons = false, jp = false }: ContactProps) => {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="LinkedIn"
-                  className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/10 px-6 py-3 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-white hover:text-black"
+                  className="inline-flex items-center gap-3 rounded-full border border-zinc-200/70 bg-white/80 px-6 py-3 text-sm font-semibold text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white dark:hover:text-black"
                 >
-                  <BsLinkedin className="h-5 w-5" />
+                  <TbBrandLinkedin className="h-5 w-5" />
                   LinkedIn
                 </AppLink>
               </div>

--- a/components/home/LandingSection.tsx
+++ b/components/home/LandingSection.tsx
@@ -23,26 +23,26 @@ const LandingSection = ({ jp = false }: LandingSectionProps) => {
   return (
     <section
       id="welcome"
-      className="relative isolate overflow-hidden bg-gradient-to-b from-black via-black/90 to-night"
+      className="relative isolate overflow-hidden bg-gradient-to-b from-white via-white/90 to-zinc-100 transition-colors duration-300 dark:from-black dark:via-black/90 dark:to-night"
     >
-      <div className="pointer-events-none absolute inset-0 -z-10 bg-hero-soft opacity-80" />
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-hero-soft opacity-60 dark:opacity-80" />
       <div className="pointer-events-none absolute -left-1/2 top-1/4 h-[36rem] w-[36rem] rounded-full bg-indigo-500/20 blur-3xl" />
       <div className="pointer-events-none absolute -right-1/3 bottom-0 h-[28rem] w-[28rem] rounded-full bg-pink-400/20 blur-3xl" />
 
       <div className="mx-auto flex min-h-[calc(100vh-6rem)] max-w-6xl flex-col-reverse items-center gap-16 px-6 pb-24 pt-32 md:flex-row md:items-end md:justify-between lg:px-12">
         <div className="max-w-2xl text-center md:text-left">
-          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-zinc-200">
+          <span className="inline-flex items-center gap-2 rounded-full border border-zinc-200/70 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-zinc-700 transition-colors duration-300 dark:border-white/10 dark:bg-white/5 dark:text-zinc-200">
             {badge}
           </span>
-          <h1 className="mt-8 text-4xl font-semibold tracking-tight text-white sm:text-5xl md:text-6xl">
+          <h1 className="mt-8 text-4xl font-semibold tracking-tight text-zinc-900 transition-colors duration-300 dark:text-white sm:text-5xl md:text-6xl">
             {headline}
           </h1>
-          <p className="mt-6 text-lg leading-relaxed text-zinc-300 sm:text-xl">{subheadline}</p>
+          <p className="mt-6 text-lg leading-relaxed text-zinc-600 transition-colors duration-300 sm:text-xl dark:text-zinc-300">{subheadline}</p>
 
           <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-start">
             <AppLink
               href="#work"
-              className="inline-flex items-center justify-center rounded-full bg-white px-8 py-3 text-sm font-semibold text-black shadow-glow transition hover:-translate-y-0.5 hover:shadow-xl"
+              className="inline-flex items-center justify-center rounded-full bg-zinc-900 px-8 py-3 text-sm font-semibold text-white shadow-lg shadow-zinc-900/20 transition hover:-translate-y-0.5 hover:bg-black dark:bg-white dark:text-black dark:shadow-glow"
             >
               {primaryCta}
             </AppLink>
@@ -50,32 +50,32 @@ const LandingSection = ({ jp = false }: LandingSectionProps) => {
               href={resumeHref}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center justify-center rounded-full border border-white/20 px-8 py-3 text-sm font-semibold text-zinc-100 transition hover:-translate-y-0.5 hover:border-white hover:text-white"
+              className="inline-flex items-center justify-center rounded-full border border-zinc-300/80 px-8 py-3 text-sm font-semibold text-zinc-700 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:text-zinc-900 dark:border-white/20 dark:text-zinc-100 dark:hover:border-white dark:hover:text-white"
             >
               {secondaryCta}
             </AppLink>
           </div>
 
-          <p className="mt-10 text-sm uppercase tracking-[0.3em] text-zinc-500">{supportingCopy}</p>
+          <p className="mt-10 text-sm uppercase tracking-[0.3em] text-zinc-500 dark:text-zinc-500">{supportingCopy}</p>
         </div>
 
         <div className="relative flex w-full max-w-xl justify-center">
-          <div className="absolute -inset-6 rounded-[2.5rem] bg-gradient-to-tr from-white/10 via-white/5 to-transparent blur-2xl" />
-          <div className="relative w-full rounded-[2.5rem] border border-white/10 bg-white/10 p-6 shadow-2xl backdrop-blur-2xl">
-            <div className="relative overflow-hidden rounded-[2rem] bg-black/70 p-6">
-              <div className="pointer-events-none absolute inset-x-10 top-0 h-40 rounded-full bg-white/20 blur-3xl" />
+          <div className="absolute -inset-6 rounded-[2.5rem] bg-gradient-to-tr from-white via-white/70 to-transparent blur-2xl dark:from-white/10 dark:via-white/5" />
+          <div className="relative w-full rounded-[2.5rem] border border-zinc-200/60 bg-white/80 p-6 shadow-2xl backdrop-blur-2xl transition-colors duration-300 dark:border-white/10 dark:bg-white/10">
+            <div className="relative overflow-hidden rounded-[2rem] bg-zinc-100 p-6 transition-colors duration-300 dark:bg-black/70">
+              <div className="pointer-events-none absolute inset-x-10 top-0 h-40 rounded-full bg-white/60 blur-3xl dark:bg-white/20" />
               <LazyImage
                 src="/images/macbook.png"
                 alt="Macbook showcasing interface"
                 className="relative z-10 mx-auto w-full max-w-sm object-contain drop-shadow-[0_40px_80px_rgba(15,23,42,0.45)] animate-float"
               />
             </div>
-            <div className="mt-6 flex items-center justify-between rounded-2xl border border-white/10 bg-black/40 px-6 py-4 text-left">
+            <div className="mt-6 flex items-center justify-between rounded-2xl border border-zinc-200/70 bg-white/70 px-6 py-4 text-left transition-colors duration-300 dark:border-white/10 dark:bg-black/40">
               <div>
                 <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">Currently</p>
-                <p className="mt-1 text-sm font-medium text-zinc-200">UI/UX Designer @ Steelcase</p>
+                <p className="mt-1 text-sm font-medium text-zinc-800 transition-colors duration-300 dark:text-zinc-200">UI/UX Designer @ Steelcase</p>
               </div>
-              <span className="text-sm font-semibold text-zinc-200">2022 — {new Date().getFullYear()}</span>
+              <span className="text-sm font-semibold text-zinc-800 transition-colors duration-300 dark:text-zinc-200">2022 — {new Date().getFullYear()}</span>
             </div>
           </div>
         </div>

--- a/components/home/WorkSection.tsx
+++ b/components/home/WorkSection.tsx
@@ -24,8 +24,8 @@ const WorkSection = ({ jp = false }: WorkSectionProps) => {
       <div className="mx-auto max-w-6xl px-6 lg:px-12">
         <Reveal animation="fade-right" className="max-w-3xl">
           <span className="text-sm uppercase tracking-[0.35em] text-zinc-500">{jp ? '実績' : 'Selected Work'}</span>
-          <h2 className="mt-4 text-3xl font-semibold text-white sm:text-4xl">{title}</h2>
-          <p className="mt-4 text-base leading-relaxed text-zinc-300 sm:text-lg">{description}</p>
+          <h2 className="mt-4 text-3xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-4xl">{title}</h2>
+          <p className="mt-4 text-base leading-relaxed text-zinc-600 transition-colors duration-300 sm:text-lg dark:text-zinc-300">{description}</p>
         </Reveal>
 
         <div className="mt-16 grid gap-12">
@@ -48,36 +48,39 @@ const ProjectHighlight = ({ project, locale, index }: ProjectHighlightProps) => 
   const copy = project.copy[locale];
   const href = locale === 'jp' ? `/jp/portfolio/${project.slug}` : `/portfolio/${project.slug}`;
   const gradientStyle = {
-    background: `linear-gradient(135deg, ${project.cardBackgroundColor} 0%, rgba(15,15,15,0.75) 65%)`,
+    background: `linear-gradient(135deg, ${project.cardBackgroundColor} 0%, rgba(15,15,15,0.65) 65%)`,
   };
 
   return (
-    <Reveal delay={150 + index * 100} className="group relative overflow-hidden rounded-[2.75rem] border border-white/10 bg-black/50 p-1 shadow-2xl">
+    <Reveal
+      delay={150 + index * 100}
+      className="group relative overflow-hidden rounded-[2.75rem] border border-zinc-200/80 bg-white/80 p-1 shadow-2xl transition-colors duration-300 dark:border-white/10 dark:bg-black/50"
+    >
       <div className="absolute inset-0 rounded-[2.75rem] opacity-0 transition duration-500 group-hover:opacity-100" style={gradientStyle} />
-      <div className="relative grid gap-10 rounded-[2.75rem] border border-white/10 bg-black/60 p-10 backdrop-blur-xl lg:grid-cols-[1.15fr_0.85fr]">
+      <div className="relative grid gap-10 rounded-[2.75rem] border border-zinc-200/80 bg-white/90 p-10 backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-black/60 lg:grid-cols-[1.15fr_0.85fr]">
         <div className="flex flex-col justify-between gap-10">
           <div className="space-y-6">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-4">
-                <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/10">
+                <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-zinc-200/70 bg-white/80 transition-colors duration-300 dark:border-white/10 dark:bg-white/10">
                   <LazyImage src={project.logo} className="h-8 w-8 object-contain" alt={`${project.cardTitle} logo`} />
                 </div>
                 <div>
                   <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">{copy.role}</p>
-                  <h3 className="mt-1 text-2xl font-semibold text-white sm:text-3xl">{project.cardTitle}</h3>
+                  <h3 className="mt-1 text-2xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-3xl">{project.cardTitle}</h3>
                 </div>
               </div>
-              <span className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-100">
+              <span className="rounded-full border border-zinc-200/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-700 transition-colors duration-300 dark:border-white/20 dark:text-zinc-100">
                 {copy.date}
               </span>
             </div>
-            <p className="text-base leading-relaxed text-zinc-300">{copy.summary}</p>
+            <p className="text-base leading-relaxed text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{copy.summary}</p>
             {project.gallery.length ? (
               <div className="flex gap-4 overflow-x-auto pb-2">
                 {project.gallery.map((image, imageIndex) => (
                   <div
                     key={`${project.slug}-detail-${imageIndex}`}
-                    className="min-w-[9rem] flex-1 overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-3 transition duration-300 hover:-translate-y-1 hover:bg-white/10"
+                    className="min-w-[9rem] flex-1 overflow-hidden rounded-2xl border border-zinc-200/70 bg-white/70 p-3 transition duration-300 hover:-translate-y-1 hover:bg-white dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
                   >
                     <LazyImage
                       src={image}
@@ -89,19 +92,19 @@ const ProjectHighlight = ({ project, locale, index }: ProjectHighlightProps) => 
               </div>
             ) : null}
           </div>
-          <div className="flex flex-col gap-3 text-sm text-zinc-400 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-3 text-sm text-zinc-600 transition-colors duration-300 sm:flex-row sm:items-center sm:justify-between dark:text-zinc-400">
             <span>{copy.roleDescription}</span>
             <AppLink
               href={href}
-              className="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-6 py-2 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:border-white"
+              className="inline-flex items-center justify-center gap-2 rounded-full border border-zinc-200/70 px-6 py-2 text-sm font-semibold text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:text-zinc-900 dark:border-white/20 dark:text-white dark:hover:border-white"
             >
               {copy.cta}
             </AppLink>
           </div>
         </div>
         <div className="relative flex items-center justify-center">
-          <div className="absolute inset-0 rounded-[2.5rem] border border-white/10 bg-white/5 blur-3xl" />
-          <div className="relative w-full rounded-[2.5rem] border border-white/10 bg-black/70 p-8">
+          <div className="absolute inset-0 rounded-[2.5rem] border border-zinc-200/70 bg-white/70 blur-3xl transition-colors duration-300 dark:border-white/10 dark:bg-white/5" />
+          <div className="relative w-full rounded-[2.5rem] border border-zinc-200/80 bg-white/90 p-8 transition-colors duration-300 dark:border-white/10 dark:bg-black/70">
             <LazyImage
               src={project.heroImage}
               className="mx-auto w-full max-w-sm object-contain drop-shadow-[0_40px_80px_rgba(15,23,42,0.45)]"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,13 @@
 import type { AppProps } from 'next/app';
+import ThemeProvider from '../components/common/ThemeProvider';
 import '../styles/style.css';
 
 const App = ({ Component, pageProps }: AppProps) => {
-  return <Component {...pageProps} />;
+  return (
+    <ThemeProvider>
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
 };
 
 export default App;

--- a/pages/portfolio/index.tsx
+++ b/pages/portfolio/index.tsx
@@ -13,11 +13,11 @@ const PortfolioListPage = () => {
   return (
     <MyLayout title="Portfolio" description="Portfolio">
       <section className="relative overflow-hidden py-24">
-        <div className="pointer-events-none absolute inset-x-0 top-0 h-72 bg-gradient-to-b from-white/10 via-transparent to-transparent blur-3xl" />
+        <div className="pointer-events-none absolute inset-x-0 top-0 h-72 bg-gradient-to-b from-sky-400/10 via-transparent to-transparent blur-3xl" />
         <div className="mx-auto max-w-6xl px-6 lg:px-12">
           <div className="max-w-3xl">
-            <h1 className="text-4xl font-semibold text-white sm:text-5xl">Selected Portfolio</h1>
-            <p className="mt-6 text-lg text-zinc-300">
+            <h1 className="text-4xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-5xl">Selected Portfolio</h1>
+            <p className="mt-6 text-lg text-zinc-600 transition-colors duration-300 dark:text-zinc-300">
               A collection of crafted UI/UX journeys built for brands spanning furniture, gaming, lifestyle, and on-demand services.
             </p>
           </div>
@@ -47,34 +47,34 @@ const ProjectCard = ({ project, locale, index }: ProjectCardProps) => {
   return (
     <Reveal
       delay={150 + index * 100}
-      className="group relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-black/50 p-1 shadow-2xl"
+      className="group relative overflow-hidden rounded-[2.5rem] border border-zinc-200/80 bg-white/80 p-1 shadow-2xl transition-colors duration-300 dark:border-white/10 dark:bg-black/50"
     >
       <div className="absolute inset-0 opacity-0 transition duration-500 group-hover:opacity-100" style={{
-        background: `linear-gradient(135deg, ${project.cardBackgroundColor} 0%, rgba(15,15,15,0.75) 70%)`,
+        background: `linear-gradient(135deg, ${project.cardBackgroundColor} 0%, rgba(15,15,15,0.65) 70%)`,
       }} />
-      <div className="relative grid gap-10 rounded-[2.5rem] border border-white/10 bg-black/60 p-8 backdrop-blur-xl lg:grid-cols-[1.15fr_0.85fr]">
+      <div className="relative grid gap-10 rounded-[2.5rem] border border-zinc-200/80 bg-white/90 p-8 backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-black/60 lg:grid-cols-[1.15fr_0.85fr]">
         <div className="space-y-6">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-4">
-              <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/10">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-zinc-200/70 bg-white/80 transition-colors duration-300 dark:border-white/10 dark:bg-white/10">
                 <LazyImage src={project.logo} className="h-8 w-8 object-contain" alt={`${project.cardTitle} logo`} />
               </div>
               <div>
                 <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">{copy.role}</p>
-                <h2 className="mt-1 text-2xl font-semibold text-white sm:text-3xl">{project.cardTitle}</h2>
+                <h2 className="mt-1 text-2xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-3xl">{project.cardTitle}</h2>
               </div>
             </div>
-            <span className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-100">
+            <span className="rounded-full border border-zinc-200/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-700 transition-colors duration-300 dark:border-white/20 dark:text-zinc-100">
               {copy.date}
             </span>
           </div>
-          <p className="text-base leading-relaxed text-zinc-300">{copy.summary}</p>
+          <p className="text-base leading-relaxed text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{copy.summary}</p>
           {project.gallery.length ? (
             <div className="flex gap-4 overflow-x-auto pb-2">
               {project.gallery.map((image, galleryIndex) => (
                 <div
                   key={`${project.slug}-gallery-${galleryIndex}`}
-                  className="min-w-[9rem] overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-3 transition duration-300 hover:-translate-y-1 hover:bg-white/10"
+                  className="min-w-[9rem] overflow-hidden rounded-2xl border border-zinc-200/70 bg-white/70 p-3 transition duration-300 hover:-translate-y-1 hover:bg-white dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
                 >
                   <LazyImage
                     src={image}
@@ -87,14 +87,14 @@ const ProjectCard = ({ project, locale, index }: ProjectCardProps) => {
           ) : null}
           <AppLink
             href={href}
-            className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:border-white"
+            className="inline-flex items-center justify-center rounded-full border border-zinc-200/70 px-6 py-3 text-sm font-semibold text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:text-zinc-900 dark:border-white/20 dark:text-white dark:hover:border-white"
           >
             View Case Study
           </AppLink>
         </div>
         <div className="relative flex items-center justify-center">
-          <div className="absolute inset-0 rounded-[2.25rem] border border-white/10 bg-white/5 blur-3xl" />
-          <div className="relative w-full rounded-[2.25rem] border border-white/10 bg-black/70 p-8">
+          <div className="absolute inset-0 rounded-[2.25rem] border border-zinc-200/70 bg-white/70 blur-3xl transition-colors duration-300 dark:border-white/10 dark:bg-white/5" />
+          <div className="relative w-full rounded-[2.25rem] border border-zinc-200/80 bg-white/90 p-8 transition-colors duration-300 dark:border-white/10 dark:bg-black/70">
             <LazyImage
               src={project.heroImage}
               className="mx-auto w-full max-w-sm object-contain drop-shadow-[0_40px_80px_rgba(15,23,42,0.45)]"

--- a/styles/style.css
+++ b/styles/style.css
@@ -21,19 +21,27 @@
   }
 
   body {
-    @apply bg-night text-zinc-100 antialiased;
+    @apply bg-zinc-50 text-zinc-900 antialiased dark:bg-night dark:text-zinc-100;
     font-family: theme('fontFamily.sans');
-    background-image: radial-gradient(120% 120% at 50% 0%, rgba(59, 130, 246, 0.12) 0%, rgba(5, 5, 5, 0) 60%);
+    background-image: var(--app-background);
     min-height: 100vh;
   }
 
   ::selection {
-    @apply bg-zinc-700 text-white;
+    @apply bg-zinc-800 text-white dark:bg-zinc-700;
   }
 
   a {
     @apply text-inherit no-underline;
   }
+}
+
+:root {
+  --app-background: radial-gradient(120% 120% at 50% 0%, rgba(37, 99, 235, 0.08) 0%, rgba(244, 244, 245, 0) 60%);
+}
+
+.dark {
+  --app-background: radial-gradient(120% 120% at 50% 0%, rgba(59, 130, 246, 0.12) 0%, rgba(5, 5, 5, 0) 60%);
 }
 
 @layer components {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- add a custom theme provider that syncs the user’s light or dark preference with local storage and the document root
- replace header language icon with Tb icons, introduce a theme toggle, and propagate light-friendly colors across key sections
- refresh global and section-level styling to support light and dark palettes with Tailwind’s class-based dark mode

## Testing
- `yarn lint` *(fails: project is not yet bootstrapped in the lockfile under the provided Yarn version)*

------
https://chatgpt.com/codex/tasks/task_b_68d74b3980d0832682220acfabd1d7d9