### PR TITLE
Fix asset paths and adjust project hover themes

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,6 +3,7 @@ import { TbMoon, TbSun, TbWorld } from 'react-icons/tb';
 import HamburgerMenu from 'react-hamburger-menu';
 import AppLink from './common/AppLink';
 import { useTheme } from './common/ThemeProvider';
+import { resolveAssetPath } from '../lib/assetPath';
 
 type HeaderProps = {
   jp?: boolean;
@@ -112,7 +113,7 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
             className="flex items-center gap-3 rounded-full px-2 py-1 text-sm font-semibold tracking-wide transition hover:opacity-80"
             onClick={closeMenu}
           >
-            <img src="/Logo.png" alt="Jia Sheng Yeap" className="h-10 w-auto" />
+            <img src={resolveAssetPath('/Logo.png')} alt="Jia Sheng Yeap" className="h-10 w-auto" />
             <span className="hidden text-sm font-medium sm:inline-flex">
               Jia Sheng Yeap {jp ? '| シェーン' : ''}
             </span>

--- a/components/LazyImage.tsx
+++ b/components/LazyImage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import type { ImgHTMLAttributes } from 'react';
 import LazyLoad from 'vanilla-lazyload';
 import lazyloadConfig from './config/lazyload';
+import { resolveAssetPath, resolveAssetSrcSet } from '../lib/assetPath';
 
 type LazyImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src' | 'srcSet'> & {
   src: string;
@@ -30,12 +31,15 @@ const LazyImage = ({
     }
   }, []);
 
+  const resolvedSrc = resolveAssetPath(src);
+  const resolvedSrcSet = resolveAssetSrcSet(srcSet);
+
   return (
     <img
       alt={alt}
       className={`lazy ${className}`.trim()}
-      data-src={src}
-      data-srcset={srcSet}
+      data-src={resolvedSrc}
+      data-srcset={resolvedSrcSet}
       data-sizes={sizes}
       width={width}
       height={height}

--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -1,9 +1,10 @@
 import AppLink from './common/AppLink';
 import LazyImage from './LazyImage';
 import type { Locale, Project } from '../data/projects';
+import { resolveAssetPath } from '../lib/assetPath';
 
-const appStoreIcon = '/images/appstore.png';
-const playStoreIcon = '/images/playstore.png';
+const appStoreIcon = resolveAssetPath('/images/appstore.png');
+const playStoreIcon = resolveAssetPath('/images/playstore.png');
 
 type ProjectDetailProps = {
   project: Project;

--- a/components/home/WorkSection.tsx
+++ b/components/home/WorkSection.tsx
@@ -48,7 +48,8 @@ const ProjectHighlight = ({ project, locale, index }: ProjectHighlightProps) => 
   const copy = project.copy[locale];
   const href = locale === 'jp' ? `/jp/portfolio/${project.slug}` : `/portfolio/${project.slug}`;
   const gradientStyle = {
-    background: `linear-gradient(135deg, ${project.cardBackgroundColor} 0%, rgba(15,15,15,0.65) 65%)`,
+    background:
+      project.hoverGradient ?? `linear-gradient(135deg, ${project.cardBackgroundColor} 0%, rgba(15,15,15,0.65) 65%)`,
   };
 
   return (

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -27,6 +27,7 @@ export type Project = {
   gallery: string[];
   cardBackgroundColor: string;
   cardTextColor: string;
+  hoverGradient?: string;
   heroBackgroundColor?: string;
   designTools?: string;
   developmentTools?: string;
@@ -43,6 +44,7 @@ const projects: Project[] = [
     gallery: [],
     cardBackgroundColor: '#272725',
     cardTextColor: '#FFFFFF',
+    hoverGradient: 'linear-gradient(135deg, rgba(248,248,248,0.95) 0%, rgba(148,163,184,0.45) 65%)',
     heroBackgroundColor: '#000000',
     designTools: 'Adobe XD, Shopify, Adobe Photoshop, Adobe Illustrator',
     developmentTools: 'Liquid Template Language (Liquid), HTML, CSS, jQuery, Javascript',
@@ -92,6 +94,7 @@ const projects: Project[] = [
     gallery: [],
     cardBackgroundColor: '#FFFFFF',
     cardTextColor: '#000000',
+    hoverGradient: 'linear-gradient(135deg, rgba(220,38,38,0.85) 0%, rgba(15,15,15,0.75) 65%)',
     heroBackgroundColor: '#000000',
     designTools: 'Adobe XD, Shopify, Adobe Photoshop, Adobe Illustrator',
     developmentTools: 'Liquid Template Language (Liquid), HTML, CSS, jQuery, Javascript',

--- a/lib/assetPath.ts
+++ b/lib/assetPath.ts
@@ -1,0 +1,73 @@
+import getConfig from 'next/config';
+
+const externalPattern = /^(?:[a-z][a-z\d+.-]*:|\/\/)/i;
+
+type NextRuntimeConfig = {
+  assetPrefix?: string;
+  basePath?: string;
+};
+
+let cachedPrefix: string | null = null;
+
+const getPrefix = () => {
+  if (cachedPrefix !== null) {
+    return cachedPrefix;
+  }
+
+  try {
+    const config = getConfig() as NextRuntimeConfig | undefined;
+    const assetPrefix = config?.assetPrefix ?? '';
+    const basePath = config?.basePath ?? '';
+    const prefix = assetPrefix || basePath || '';
+
+    cachedPrefix = prefix.replace(/\/$/, '');
+    return cachedPrefix;
+  } catch (error) {
+    cachedPrefix = '';
+    return cachedPrefix;
+  }
+};
+
+export const resolveAssetPath = (path: string) => {
+  if (!path) {
+    return path;
+  }
+
+  if (externalPattern.test(path) || path.startsWith('data:') || path.startsWith('blob:')) {
+    return path;
+  }
+
+  const prefix = getPrefix();
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  if (!prefix) {
+    return normalizedPath;
+  }
+
+  return normalizedPath.startsWith(`${prefix}/`) ? normalizedPath : `${prefix}${normalizedPath}`;
+};
+
+export const resolveAssetSrcSet = (srcSet?: string) => {
+  if (!srcSet) {
+    return undefined;
+  }
+
+  return srcSet
+    .split(',')
+    .map((candidate) => {
+      const trimmed = candidate.trim();
+
+      if (!trimmed) {
+        return '';
+      }
+
+      const [source, ...descriptorParts] = trimmed.split(/\s+/);
+      const descriptor = descriptorParts.join(' ');
+      const resolvedSource = resolveAssetPath(source);
+
+      return descriptor ? `${resolvedSource} ${descriptor}` : resolvedSource;
+    })
+    .filter(Boolean)
+    .join(', ');
+};
+

--- a/pages/jp/portfolio/index.tsx
+++ b/pages/jp/portfolio/index.tsx
@@ -49,9 +49,13 @@ const ProjectCard = ({ project, locale, index }: ProjectCardProps) => {
       delay={150 + index * 100}
       className="group relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-black/50 p-1 shadow-2xl"
     >
-      <div className="absolute inset-0 opacity-0 transition duration-500 group-hover:opacity-100" style={{
-        background: `linear-gradient(135deg, ${project.cardBackgroundColor} 0%, rgba(15,15,15,0.75) 70%)`,
-      }} />
+      <div
+        className="absolute inset-0 opacity-0 transition duration-500 group-hover:opacity-100"
+        style={{
+          background:
+            project.hoverGradient ?? `linear-gradient(135deg, ${project.cardBackgroundColor} 0%, rgba(15,15,15,0.75) 70%)`,
+        }}
+      />
       <div className="relative grid gap-10 rounded-[2.5rem] border border-white/10 bg-black/60 p-8 backdrop-blur-xl lg:grid-cols-[1.15fr_0.85fr]">
         <div className="space-y-6">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/pages/portfolio/index.tsx
+++ b/pages/portfolio/index.tsx
@@ -49,9 +49,13 @@ const ProjectCard = ({ project, locale, index }: ProjectCardProps) => {
       delay={150 + index * 100}
       className="group relative overflow-hidden rounded-[2.5rem] border border-zinc-200/80 bg-white/80 p-1 shadow-2xl transition-colors duration-300 dark:border-white/10 dark:bg-black/50"
     >
-      <div className="absolute inset-0 opacity-0 transition duration-500 group-hover:opacity-100" style={{
-        background: `linear-gradient(135deg, ${project.cardBackgroundColor} 0%, rgba(15,15,15,0.65) 70%)`,
-      }} />
+      <div
+        className="absolute inset-0 opacity-0 transition duration-500 group-hover:opacity-100"
+        style={{
+          background:
+            project.hoverGradient ?? `linear-gradient(135deg, ${project.cardBackgroundColor} 0%, rgba(15,15,15,0.65) 70%)`,
+        }}
+      />
       <div className="relative grid gap-10 rounded-[2.5rem] border border-zinc-200/80 bg-white/90 p-8 backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-black/60 lg:grid-cols-[1.15fr_0.85fr]">
         <div className="space-y-6">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">


### PR DESCRIPTION
## Summary
- add an asset path helper that respects Next.js base paths and reuse it anywhere raw image URLs are used
- update lazy image loading, the header logo, and project detail store badges to ensure images resolve correctly in production
- add explicit hover gradients so TTRacing uses a red accent while Steelcase gets a light grey overlay across work and portfolio sections

## Testing
- yarn install --immutable *(fails: registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_b_68d74e4c27e4832694114aab7effd439