### PR TITLE
Adjust project hover gradients and lazy image visibility

### DIFF
--- a/components/home/WorkSection.tsx
+++ b/components/home/WorkSection.tsx
@@ -47,8 +47,13 @@ type ProjectHighlightProps = {
 const ProjectHighlight = ({ project, locale, index }: ProjectHighlightProps) => {
   const copy = project.copy[locale];
   const href = locale === 'jp' ? `/jp/portfolio/${project.slug}` : `/portfolio/${project.slug}`;
+  const [gradientStart, gradientEnd] = project.cardHoverGradient ?? [
+    project.cardBackgroundColor,
+    'rgba(15,15,15,0.65)',
+  ];
+
   const gradientStyle = {
-    background: `linear-gradient(135deg, ${project.cardBackgroundColor} 0%, rgba(15,15,15,0.65) 65%)`,
+    background: `linear-gradient(135deg, ${gradientStart} 0%, ${gradientEnd} 100%)`,
   };
 
   return (

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -27,6 +27,7 @@ export type Project = {
   gallery: string[];
   cardBackgroundColor: string;
   cardTextColor: string;
+  cardHoverGradient?: [string, string];
   heroBackgroundColor?: string;
   designTools?: string;
   developmentTools?: string;
@@ -43,6 +44,7 @@ const projects: Project[] = [
     gallery: [],
     cardBackgroundColor: '#272725',
     cardTextColor: '#FFFFFF',
+    cardHoverGradient: ['#444444', '#FFFFFF'],
     heroBackgroundColor: '#000000',
     designTools: 'Adobe XD, Shopify, Adobe Photoshop, Adobe Illustrator',
     developmentTools: 'Liquid Template Language (Liquid), HTML, CSS, jQuery, Javascript',
@@ -92,6 +94,7 @@ const projects: Project[] = [
     gallery: [],
     cardBackgroundColor: '#FFFFFF',
     cardTextColor: '#000000',
+    cardHoverGradient: ['#D12028', '#FFFFFF'],
     heroBackgroundColor: '#000000',
     designTools: 'Adobe XD, Shopify, Adobe Photoshop, Adobe Illustrator',
     developmentTools: 'Liquid Template Language (Liquid), HTML, CSS, jQuery, Javascript',

--- a/styles/style.css
+++ b/styles/style.css
@@ -92,12 +92,19 @@
   }
 
   .lazy {
-    opacity: 0;
+    opacity: 1;
     transition: opacity 0.5s ease;
     will-change: opacity;
   }
 
-  .lazy.lazy-loaded {
+  .lazy[data-ll-status='loading'],
+  .lazy[data-ll-status='entered'] {
+    opacity: 0;
+  }
+
+  .lazy.lazy-loaded,
+  .lazy[data-ll-status='loaded'],
+  .lazy[data-ll-status='applied'] {
     opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary
- add per-project hover gradient configuration to featured work cards
- update TTRacing and Steelcase hover treatments to use brand-inspired color pairs
- tweak lazy image styles so assets remain visible until lazy loading activates

## Testing
- yarn lint *(fails: package missing from lockfile in the container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d753a622648326b7d584d628545ec2