### PR TITLE
Improve light theme contrast and enlarge hero visuals

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -47,7 +47,7 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
   const wrapperClasses = [
     'fixed inset-x-0 top-0 z-50 transition-all duration-300 ease-out',
     isTransparent
-      ? 'bg-transparent text-white'
+      ? 'bg-transparent text-zinc-900 dark:text-white'
       : 'border-b border-zinc-200/70 bg-white/80 text-zinc-900 shadow-lg shadow-zinc-900/5 backdrop-blur-xl dark:border-white/10 dark:bg-black/80 dark:text-zinc-100 dark:shadow-black/10',
   ]
     .filter(Boolean)
@@ -112,7 +112,7 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
             className="flex items-center gap-3 rounded-full px-2 py-1 text-sm font-semibold tracking-wide transition hover:opacity-80"
             onClick={closeMenu}
           >
-            <img src="/Logo.png" alt="Jia Sheng Yeap" className="h-10 w-auto" />
+            <img src="/Logo.png" alt="Jia Sheng Yeap" className="h-12 w-auto sm:h-14" />
             <span className="hidden text-sm font-medium sm:inline-flex">
               Jia Sheng Yeap {jp ? '| シェーン' : ''}
             </span>
@@ -135,7 +135,7 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
             width={22}
             height={18}
             strokeWidth={2}
-            color={isTransparent ? '#f4f4f5' : isDark ? '#f4f4f5' : '#18181b'}
+            color={isTransparent ? (isDark ? '#f4f4f5' : '#18181b') : isDark ? '#f4f4f5' : '#18181b'}
             animationDuration={0.5}
           />
         </button>

--- a/components/home/About.tsx
+++ b/components/home/About.tsx
@@ -93,10 +93,10 @@ const About = ({ jp = false }: { jp?: boolean }) => {
                 <Reveal
                   key={card.title}
                   animation="fade-up"
-                  className="rounded-2xl border border-zinc-200/70 bg-white/70 p-6 transition hover:-translate-y-1 hover:bg-white dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
+                  className="flex min-h-[12rem] flex-col gap-3 rounded-2xl border border-zinc-200/70 bg-white/70 p-6 transition hover:-translate-y-1 hover:bg-white dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
                 >
                   <h3 className="text-lg font-semibold text-zinc-900 transition-colors duration-300 dark:text-white">{card.title}</h3>
-                  <p className="mt-2 text-sm leading-relaxed text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{card.description}</p>
+                  <p className="mt-auto text-sm leading-relaxed text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{card.description}</p>
                 </Reveal>
               ))}
             </div>

--- a/components/home/LandingSection.tsx
+++ b/components/home/LandingSection.tsx
@@ -67,7 +67,7 @@ const LandingSection = ({ jp = false }: LandingSectionProps) => {
               <LazyImage
                 src="/images/macbook.png"
                 alt="Macbook showcasing interface"
-                className="relative z-10 mx-auto w-full max-w-sm object-contain drop-shadow-[0_40px_80px_rgba(15,23,42,0.45)] animate-float"
+                className="relative z-10 mx-auto w-full max-w-lg object-contain drop-shadow-[0_40px_80px_rgba(15,23,42,0.45)] animate-float md:max-w-xl"
               />
             </div>
             <div className="mt-6 flex items-center justify-between rounded-2xl border border-zinc-200/70 bg-white/70 px-6 py-4 text-left transition-colors duration-300 dark:border-white/10 dark:bg-black/40">

--- a/components/home/WorkSection.tsx
+++ b/components/home/WorkSection.tsx
@@ -112,7 +112,7 @@ const ProjectHighlight = ({ project, locale, index }: ProjectHighlightProps) => 
           <div className="relative w-full rounded-[2.5rem] border border-zinc-200/80 bg-white/90 p-8 transition-colors duration-300 dark:border-white/10 dark:bg-black/70">
             <LazyImage
               src={project.heroImage}
-              className="mx-auto w-full max-w-sm object-contain drop-shadow-[0_40px_80px_rgba(15,23,42,0.45)]"
+              className="mx-auto w-full max-w-lg object-contain drop-shadow-[0_40px_80px_rgba(15,23,42,0.45)]"
               alt={`${project.cardTitle} preview`}
             />
           </div>


### PR DESCRIPTION
## Summary
- update the transparent header styles so the light theme uses dark typography and grow the logo for better legibility
- scale up the hero imagery on the landing and project highlight cards to give the visuals more prominence
- give the about section highlight cards a fixed minimum height to keep the layout consistent across differing content lengths

## Testing
- yarn lint *(fails: Yarn 4 in the environment refuses to use the existing lockfile; dependencies were not reinstalled)*

------
https://chatgpt.com/codex/tasks/task_b_68d755eea0c48326864b2d0fa9db8dd9