### PR TITLE
Preserve current page when toggling language

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { TbMoon, TbSun, TbWorld } from 'react-icons/tb';
 import HamburgerMenu from 'react-hamburger-menu';
 import AppLink from './common/AppLink';
 import { useTheme } from './common/ThemeProvider';
+import { useRouter } from 'next/router';
 
 type HeaderProps = {
   jp?: boolean;
@@ -36,9 +37,26 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
     setOpen(false);
   };
 
+  const { asPath } = useRouter();
+
   const portfolioHref = jp ? '/jp/portfolio' : '/portfolio';
   const resumeHref = jp ? '/Resume(JiaSheng)Japanese.pdf' : '/Resume(Jia Sheng).pdf';
-  const languageHref = jp ? '/' : '/jp';
+  const languageHref = useMemo(() => {
+    if (jp) {
+      const englishPath = asPath.replace(/^\/jp(?=\/|$)/, '') || '/';
+      return englishPath.startsWith('/') ? englishPath : `/${englishPath}`;
+    }
+
+    if (asPath === '/' || asPath === '') {
+      return '/jp';
+    }
+
+    if (asPath.startsWith('/jp')) {
+      return asPath;
+    }
+
+    return `/jp${asPath.startsWith('/') ? '' : '/'}${asPath}`;
+  }, [asPath, jp]);
   const languageLabel = jp ? '日本語' : 'English';
   const portfolioLabel = jp ? 'ポートフォリオ' : 'Portfolio';
   const resumeLabel = jp ? '履歴書' : 'Resume';


### PR DESCRIPTION
## Summary
- derive the language switch link from the current route so toggling languages keeps users on the same page

## Testing
- yarn lint *(fails: dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d774444c688326a2075db6d5d7c816