### PR TITLE
Add header language selector and theme switch

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -87,16 +87,18 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
       role="switch"
       aria-checked={isDark}
       aria-label={jp ? 'テーマを切り替える' : 'Toggle theme'}
-      className={`relative inline-flex h-7 w-12 items-center rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-900 ${
-        isDark ? 'bg-zinc-700 dark:bg-zinc-600' : 'bg-zinc-300 dark:bg-zinc-700'
+      className={`group relative inline-flex h-9 w-16 items-center overflow-hidden rounded-full transition-colors duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-900 ${
+        isDark ? 'bg-zinc-800 dark:bg-zinc-700' : 'bg-zinc-200 dark:bg-zinc-600'
       }`}
     >
       <span
-        className={`absolute inset-y-0 left-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-white text-zinc-700 transition ${
-          isDark ? 'translate-x-5' : 'translate-x-0'
+        className={`inline-flex h-full w-1/2 items-center justify-center rounded-full bg-white text-zinc-700 shadow transition duration-300 ease-out ${
+          isDark
+            ? 'translate-x-full text-indigo-200 group-hover:text-indigo-100'
+            : 'translate-x-0 text-amber-400 group-hover:text-amber-300'
         }`}
       >
-        {isDark ? <TbMoon className="h-3.5 w-3.5" /> : <TbSun className="h-3.5 w-3.5" />}
+        {isDark ? <TbMoon className="h-4 w-4" /> : <TbSun className="h-4 w-4" />}
       </span>
     </button>
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -87,16 +87,14 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
       role="switch"
       aria-checked={isDark}
       aria-label={jp ? 'テーマを切り替える' : 'Toggle theme'}
-      className={`group relative inline-flex h-9 w-16 items-center overflow-hidden rounded-full transition-colors duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-900 ${
-        isDark ? 'bg-zinc-800 dark:bg-zinc-700' : 'bg-zinc-200 dark:bg-zinc-600'
-      }`}
+      className={`group relative inline-flex h-8 w-16 items-center overflow-hidden rounded-full transition-colors duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-900 ${isDark ? 'bg-zinc-800 dark:bg-zinc-700' : 'bg-zinc-200 dark:bg-zinc-600'
+        }`}
     >
       <span
-        className={`inline-flex h-full w-1/2 items-center justify-center rounded-full bg-white text-zinc-700 shadow transition duration-300 ease-out ${
-          isDark
-            ? 'translate-x-full text-indigo-200 group-hover:text-indigo-100'
-            : 'translate-x-0 text-amber-400 group-hover:text-amber-300'
-        }`}
+        className={`inline-flex h-8 w-8 items-center justify-center rounded-full bg-white text-zinc-700 shadow transition duration-300 ease-out ${isDark
+          ? 'translate-x-full text-indigo-200 group-hover:text-indigo-100'
+          : 'translate-x-0 text-amber-400 group-hover:text-amber-300'
+          }`}
       >
         {isDark ? <TbMoon className="h-4 w-4" /> : <TbSun className="h-4 w-4" />}
       </span>


### PR DESCRIPTION
## Summary
- replace the header language link with a dropdown selector for English and Japanese navigation
- restyle the theme toggle as an accessible switch control that reflects the current mode

## Testing
- yarn lint *(fails: Yarn 4 cannot find the workspace entry without reinstalling dependencies)*
- npm run lint *(fails: `next lint` resolves to an unexpected `lint` directory in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d777a0b7a88326b02bf43a5ef0af55