### PR TITLE
Standardize typography across the site

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,10 +9,10 @@ const Footer = ({ jp = false }: FooterProps) => {
 
   return (
     <footer className="border-t border-zinc-200/80 bg-white/80 backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-black/60">
-      <div className="layout-container flex flex-col gap-4 py-12 text-sm text-zinc-600 transition-colors duration-300 md:flex-row md:items-center md:justify-center dark:text-zinc-400">
+      <div className="layout-container flex flex-col gap-4 py-12 text-zinc-600 transition-colors duration-300 md:flex-row md:items-center md:justify-center dark:text-zinc-400">
         <div>
-          <p className="text-base text-center font-semibold tracking-wide text-zinc-800 dark:text-zinc-200">Jia Sheng Yeap</p>
-          <p className="mt-1 max-w-xl text-center">
+          <p className="typography-subheading text-center tracking-wide text-zinc-800 dark:text-zinc-200">Jia Sheng Yeap</p>
+          <p className="typography-body mt-1 max-w-xl text-center">
             {jp
               ? 'デジタル製品、ブランド体験、シームレスなUI/UXをデザインし、開発します。'
               : 'Designing and developing immersive digital products, brand stories, and seamless UI/UX experiences.'}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -134,7 +134,7 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
           href={resumeHref}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center rounded-full px-4 py-2 text-sm font-medium text-zinc-700 transition hover:-translate-y-0.5 hover:bg-white hover:text-zinc-900 dark:text-zinc-100 dark:hover:bg-white dark:hover:text-black"
+          className="inline-flex items-center rounded-full px-4 py-2 typography-button text-zinc-700 transition hover:-translate-y-0.5 hover:bg-white hover:text-zinc-900 dark:text-zinc-100 dark:hover:bg-white dark:hover:text-black"
           onClick={closeMenu}
         >
           {resumeLabel}
@@ -151,7 +151,7 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
             value={jp ? 'jp' : 'en'}
             onChange={handleLanguageChange}
             style={{ borderRight: '16px solid transparent' }}
-            className="rounded-full border border-transparent bg-white/70 px-4 py-2 text-sm font-medium text-zinc-700 transition hover:-translate-y-0.5 hover:bg-white focus:border-zinc-400 focus:outline-none border-none dark:bg-white/10 dark:text-zinc-100 dark:hover:bg-white/20 dark:focus:border-zinc-500"
+            className="rounded-full border border-transparent bg-white/70 px-4 py-2 typography-button text-zinc-700 transition hover:-translate-y-0.5 hover:bg-white focus:border-zinc-400 focus:outline-none border-none dark:bg-white/10 dark:text-zinc-100 dark:hover:bg-white/20 dark:focus:border-zinc-500"
           >
             <option value="en">English</option>
             <option value="jp">日本語</option>
@@ -170,11 +170,11 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
         <div className="flex items-center gap-8">
           <AppLink
             href={jp ? '/jp' : '/'}
-            className="flex items-center gap-3 rounded-full px-2 py-1 text-sm font-semibold tracking-wide transition hover:opacity-80"
+            className="flex items-center gap-3 rounded-full px-2 py-1 typography-button tracking-wide transition hover:opacity-80"
             onClick={closeMenu}
           >
             <img src="/Logo.png" alt="Jia Sheng Yeap" className="h-12 w-auto sm:h-14" />
-            <span className="hidden text-sm font-medium sm:inline-flex">
+            <span className="hidden typography-body-sm font-medium sm:inline-flex">
               {jp ? 'シェン' : 'Jia Sheng Yeap'}
             </span>
           </AppLink>
@@ -210,7 +210,7 @@ const Header = ({ jp = false, overlay = false }: HeaderProps) => {
         >
           <nav
             aria-label="Mobile"
-            className="flex list-none flex-col gap-6 text-lg text-zinc-800 dark:text-zinc-100"
+            className="flex list-none flex-col gap-6 text-zinc-800 dark:text-zinc-100"
           >
             <NavigationLinks />
           </nav>

--- a/components/ProjectDetail.tsx
+++ b/components/ProjectDetail.tsx
@@ -30,9 +30,9 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
       <section className="relative isolate overflow-hidden border-b border-zinc-200/70 transition-colors duration-300 dark:border-white/10" style={heroStyle}>
         {/* <div className="absolute inset-0 bg-white/80 dark:bg-black/65" /> */}
         <div className="section-spacing layout-container--narrow flex flex-col items-center gap-10 text-center">
-          <span className="text-xs uppercase tracking-[0.4em] text-zinc-500">{copy.date}</span>
-          <h1 className="text-3xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-5xl">{copy.title}</h1>
-          <p className="max-w-3xl text-base text-zinc-700 transition-colors duration-300 sm:text-lg dark:text-zinc-200">{copy.summary}</p>
+          <span className="typography-meta text-zinc-500 transition-colors duration-300 dark:text-zinc-400">{copy.date}</span>
+          <h1 className="typography-display text-zinc-900 transition-colors duration-300 dark:text-white">{copy.title}</h1>
+          <p className="typography-body max-w-3xl text-zinc-700 transition-colors duration-300 dark:text-zinc-200">{copy.summary}</p>
           <div className="relative w-full max-w-3xl">
             <div className="absolute inset-0 rounded-[3rem] bg-white/70 blur-3xl transition-colors duration-300 dark:bg-white/10" />
             {/* <div className="relative overflow-hidden rounded-[3rem] border border-zinc-200/70 bg-white/90 p-12 backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-black/70">
@@ -50,10 +50,12 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
         <div className="layout-container flex flex-col gap-16 lg:flex-row">
           <div className="flex-1 space-y-8">
             <div>
-              <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{overviewTitle}</p>
-              <div className="mt-4 space-y-4 text-base leading-relaxed text-zinc-700 transition-colors duration-300 dark:text-zinc-300">
+              <p className="typography-meta text-zinc-500 transition-colors duration-300 dark:text-zinc-400">{overviewTitle}</p>
+              <div className="mt-4 space-y-4 text-zinc-700 transition-colors duration-300 dark:text-zinc-300">
                 {copy.overview.map((paragraph, index) => (
-                  <p key={`${project.slug}-overview-${index}`}>{paragraph}</p>
+                  <p key={`${project.slug}-overview-${index}`} className="typography-body">
+                    {paragraph}
+                  </p>
                 ))}
               </div>
             </div>
@@ -75,7 +77,7 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
 
             {project.gallery.length ? (
               <div>
-                <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{locale === 'jp' ? 'ビジュアル' : 'Gallery'}</p>
+                <p className="typography-meta text-zinc-500 transition-colors duration-300 dark:text-zinc-400">{locale === 'jp' ? 'ビジュアル' : 'Gallery'}</p>
                 <div className="mt-4 grid gap-4 sm:grid-cols-2">
                   {project.gallery.map((image, index) => (
                     <div
@@ -92,19 +94,19 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
 
           <aside className="w-full max-w-xl space-y-8 rounded-[2.5rem] border border-zinc-200/80 bg-white/90 p-8 shadow-2xl backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-black/60">
             <div className="space-y-2">
-              <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{roleLabel}</p>
-              <p className="text-lg font-semibold text-zinc-900 transition-colors duration-300 dark:text-white">{copy.role}</p>
-              <p className="text-sm leading-relaxed text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{copy.roleDescription}</p>
+              <p className="typography-meta text-zinc-500 transition-colors duration-300 dark:text-zinc-400">{roleLabel}</p>
+              <p className="typography-subheading text-zinc-900 transition-colors duration-300 dark:text-white">{copy.role}</p>
+              <p className="typography-body-sm text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{copy.roleDescription}</p>
             </div>
             <div>
-              <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{linksLabel}</p>
+              <p className="typography-meta text-zinc-500 transition-colors duration-300 dark:text-zinc-400">{linksLabel}</p>
               <div className="mt-4 flex flex-wrap gap-3">
                 {project.links?.appStore ? (
                   <AppLink
                     href={project.links.appStore}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-3 rounded-2xl border border-zinc-200/70 bg-white/80 px-5 py-3 text-sm font-semibold text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white dark:hover:text-black"
+                    className="inline-flex items-center gap-3 rounded-2xl border border-zinc-200/70 bg-white/80 px-5 py-3 typography-button text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white dark:hover:text-black"
                   >
                     <img src={appStoreIcon} alt="App Store" className="h-5 w-auto" />
                     App Store
@@ -115,7 +117,7 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
                     href={project.links.playStore}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-3 rounded-2xl border border-zinc-200/70 bg-white/80 px-5 py-3 text-sm font-semibold text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white dark:hover:text-black"
+                    className="inline-flex items-center gap-3 rounded-2xl border border-zinc-200/70 bg-white/80 px-5 py-3 typography-button text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white dark:hover:text-black"
                   >
                     <img src={playStoreIcon} alt="Google Play" className="h-5 w-auto" />
                     Google Play
@@ -126,7 +128,7 @@ const ProjectDetail = ({ project, locale }: ProjectDetailProps) => {
                     href={project.links.website.href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-3 rounded-2xl border border-zinc-200/70 bg-white/80 px-5 py-3 text-sm font-semibold text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white dark:hover:text-black"
+                    className="inline-flex items-center gap-3 rounded-2xl border border-zinc-200/70 bg-white/80 px-5 py-3 typography-button text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white dark:hover:text-black"
                   >
                     <span>
                       {locale === 'jp' ? 'ウェブサイト' : 'Visit Website'}

--- a/components/home/About.tsx
+++ b/components/home/About.tsx
@@ -54,21 +54,21 @@ const About = ({ jp = false }: { jp?: boolean }) => {
 
       <div className="layout-container grid gap-16 md:grid-cols-[1.1fr_0.9fr]">
         <Reveal animation="fade-right" className="space-y-8">
-          <span className="text-sm uppercase tracking-[0.35em] text-zinc-500">{jp ? '紹介' : 'About'}</span>
-          <h2 className="text-3xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-4xl">{heading}</h2>
+          <span className="typography-eyebrow text-zinc-500 transition-colors duration-300 dark:text-zinc-400">{jp ? '紹介' : 'About'}</span>
+          <h2 className="typography-heading text-zinc-900 transition-colors duration-300 dark:text-white">{heading}</h2>
           {intro.map((paragraph, index) => (
-            <p key={`intro-${index}`} className="text-base leading-relaxed text-zinc-600 transition-colors duration-300 sm:text-lg dark:text-zinc-300">
+            <p key={`intro-${index}`} className="typography-body text-zinc-600 transition-colors duration-300 dark:text-zinc-300">
               {paragraph}
             </p>
           ))}
 
           <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{jp ? 'フォーカス' : 'Focus Areas'}</p>
+            <p className="typography-meta text-zinc-500 transition-colors duration-300 dark:text-zinc-400">{jp ? 'フォーカス' : 'Focus Areas'}</p>
             <div className="mt-4 flex flex-wrap gap-3">
               {focusItems.map((item) => (
                 <span
                   key={item}
-                  className="rounded-full border border-zinc-200/70 bg-white/70 px-4 py-2 text-sm font-medium text-zinc-700 shadow-sm transition-colors duration-300 dark:border-white/10 dark:bg-white/5 dark:text-zinc-200"
+                  className="rounded-full border border-zinc-200/70 bg-white/70 px-4 py-2 typography-body-sm font-medium text-zinc-700 shadow-sm transition-colors duration-300 dark:border-white/10 dark:bg-white/5 dark:text-zinc-200"
                 >
                   {item}
                 </span>
@@ -95,8 +95,8 @@ const About = ({ jp = false }: { jp?: boolean }) => {
                   animation="fade-up"
                   className="flex min-h-[12rem] flex-col gap-3 rounded-2xl border border-zinc-200/70 bg-white/70 p-6 transition hover:-translate-y-1 hover:bg-white dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
                 >
-                  <h3 className="text-lg font-semibold text-zinc-900 transition-colors duration-300 dark:text-white">{card.title}</h3>
-                  <p className="mt-auto text-sm leading-relaxed text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{card.description}</p>
+                  <h3 className="typography-subheading text-zinc-900 transition-colors duration-300 dark:text-white">{card.title}</h3>
+                  <p className="typography-body-sm mt-auto text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{card.description}</p>
                 </Reveal>
               ))}
             </div>

--- a/components/home/Contact.tsx
+++ b/components/home/Contact.tsx
@@ -24,9 +24,9 @@ const Contact = ({ icons = false, jp = false }: ContactProps) => {
         >
           <div className="pointer-events-none absolute inset-0 bg-hero-radial opacity-40 dark:opacity-60" />
           <div className="relative space-y-6">
-            <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">{jp ? 'コンタクト' : 'Connect'}</p>
-            <h2 className="text-3xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-4xl">{heading}</h2>
-            <p className="mx-auto max-w-2xl text-base text-zinc-600 transition-colors duration-300 sm:text-lg dark:text-zinc-300">{subheading}</p>
+            <p className="typography-meta text-zinc-500 transition-colors duration-300 dark:text-zinc-400">{jp ? 'コンタクト' : 'Connect'}</p>
+            <h2 className="typography-heading text-zinc-900 transition-colors duration-300 dark:text-white">{heading}</h2>
+            <p className="typography-body mx-auto max-w-2xl text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{subheading}</p>
             {icons ? (
               <div className="flex items-center justify-center gap-4">
                 <AppLink
@@ -34,7 +34,7 @@ const Contact = ({ icons = false, jp = false }: ContactProps) => {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="LinkedIn"
-                  className="inline-flex items-center gap-3 rounded-full border border-zinc-200/70 bg-white/80 px-6 py-3 text-sm font-semibold text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white dark:hover:text-black"
+                  className="inline-flex items-center gap-3 rounded-full border border-zinc-200/70 bg-white/80 px-6 py-3 typography-button text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:bg-white hover:text-zinc-900 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white dark:hover:text-black"
                 >
                   <TbBrandLinkedin className="h-5 w-5" />
                   LinkedIn

--- a/components/home/LandingSection.tsx
+++ b/components/home/LandingSection.tsx
@@ -34,15 +34,15 @@ const LandingSection = ({ jp = false }: LandingSectionProps) => {
           {/* <span className="inline-flex items-center gap-2 rounded-full border border-zinc-200/70 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-zinc-700 transition-colors duration-300 dark:border-white/10 dark:bg-white/5 dark:text-zinc-200">
             {badge}
           </span> */}
-          <h1 className="text-4xl font-semibold tracking-tight text-zinc-900 transition-colors duration-300 dark:text-white sm:text-5xl md:text-6xl">
+          <h1 className="typography-display text-zinc-900 transition-colors duration-300 dark:text-white">
             {headline}
           </h1>
-          <p className="mt-6 text-lg leading-relaxed text-zinc-600 transition-colors duration-300 sm:text-xl dark:text-zinc-300">{subheadline}</p>
+          <p className="typography-body-lg mt-6 text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{subheadline}</p>
 
           <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-start">
             <AppLink
               href="#work"
-              className="inline-flex items-center justify-center rounded-full bg-zinc-900 px-8 py-3 text-sm font-semibold text-white shadow-lg shadow-zinc-900/20 transition hover:-translate-y-0.5 hover:bg-black dark:bg-white dark:text-black dark:shadow-glow"
+              className="inline-flex items-center justify-center rounded-full bg-zinc-900 px-8 py-3 typography-button text-white shadow-lg shadow-zinc-900/20 transition hover:-translate-y-0.5 hover:bg-black dark:bg-white dark:text-black dark:shadow-glow"
             >
               {primaryCta}
             </AppLink>
@@ -50,7 +50,7 @@ const LandingSection = ({ jp = false }: LandingSectionProps) => {
               href={resumeHref}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center justify-center rounded-full border border-zinc-300/80 px-8 py-3 text-sm font-semibold text-zinc-700 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:text-zinc-900 dark:border-white/20 dark:text-zinc-100 dark:hover:border-white dark:hover:text-white"
+              className="inline-flex items-center justify-center rounded-full border border-zinc-300/80 px-8 py-3 typography-button text-zinc-700 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:text-zinc-900 dark:border-white/20 dark:text-zinc-100 dark:hover:border-white dark:hover:text-white"
             >
               {secondaryCta}
             </AppLink>

--- a/components/home/WorkSection.tsx
+++ b/components/home/WorkSection.tsx
@@ -23,9 +23,9 @@ const WorkSection = ({ jp = false }: WorkSectionProps) => {
       <div className="pointer-events-none absolute -bottom-32 left-0 h-72 w-72 rounded-full bg-purple-500/10 blur-3xl" />
       <div className="layout-container">
         <Reveal animation="fade-right" className="max-w-3xl">
-          <span className="text-sm uppercase tracking-[0.35em] text-zinc-500">{jp ? '実績' : 'Selected Work'}</span>
-          <h2 className="mt-4 text-3xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-4xl">{title}</h2>
-          <p className="mt-4 text-base leading-relaxed text-zinc-600 transition-colors duration-300 sm:text-lg dark:text-zinc-300">{description}</p>
+          <span className="typography-eyebrow text-zinc-500 transition-colors duration-300 dark:text-zinc-400">{jp ? '実績' : 'Selected Work'}</span>
+          <h2 className="mt-4 typography-heading text-zinc-900 transition-colors duration-300 dark:text-white">{title}</h2>
+          <p className="mt-4 typography-body text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{description}</p>
         </Reveal>
 
         <div className="mt-16 grid gap-12">
@@ -69,14 +69,14 @@ const ProjectHighlight = ({ project, locale, index }: ProjectHighlightProps) => 
               <div className="flex items-center gap-4">
                 <div>
                   {/* <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">{copy.role}</p> */}
-                  <h3 className="mt-1 text-2xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-3xl">{project.cardTitle}</h3>
+                  <h3 className="mt-1 typography-subheading text-zinc-900 transition-colors duration-300 dark:text-white">{project.cardTitle}</h3>
                 </div>
               </div>
               {/* <span className="rounded-full border border-zinc-200/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-700 transition-colors duration-300 dark:border-white/20 dark:text-zinc-100">
                 {copy.date}
               </span> */}
             </div>
-            <p className="text-base leading-relaxed text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{copy.summary}</p>
+            <p className="typography-body text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{copy.summary}</p>
             {/* {project.gallery.length ? (
               <div className="flex gap-4 overflow-x-auto pb-2">
                 {project.gallery.map((image, imageIndex) => (
@@ -101,11 +101,11 @@ const ProjectHighlight = ({ project, locale, index }: ProjectHighlightProps) => 
             <LazyImage src={project.logo} className="object-contain" alt={`${project.cardTitle} logo`} />
           </div>
         </div> */}
-        <div className="flex flex-col gap-3 text-sm text-zinc-600 transition-colors duration-300 sm:flex-row sm:items-center sm:justify-between dark:text-zinc-400">
+        <div className="flex flex-col gap-3 text-zinc-600 transition-colors duration-300 sm:flex-row sm:items-center sm:justify-between dark:text-zinc-400">
           {/* <span>{copy.roleDescription}</span> */}
           <AppLink
             href={href}
-            className="whitespace-nowrap inline-flex items-center justify-center gap-2 rounded-full border border-zinc-200/70 px-6 py-2 text-lg font-semibold text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:text-zinc-900 dark:border-white/20 dark:text-white dark:hover:border-white"
+            className="whitespace-nowrap inline-flex items-center justify-center gap-2 rounded-full border border-zinc-200/70 px-6 py-2 typography-button text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:text-zinc-900 dark:border-white/20 dark:text-white dark:hover:border-white"
           >
             {copy.cta}
           </AppLink>

--- a/pages/jp/portfolio/index.tsx
+++ b/pages/jp/portfolio/index.tsx
@@ -16,8 +16,8 @@ const PortfolioListPage = () => {
         <div className="pointer-events-none absolute inset-x-0 top-0 h-72 bg-gradient-to-b from-white/10 via-transparent to-transparent blur-3xl" />
         <div className="layout-container">
           <div className="max-w-3xl">
-            <h1 className="text-4xl font-semibold text-white sm:text-5xl">厳選した制作実績</h1>
-            <p className="mt-6 text-lg text-zinc-300">
+            <h1 className="typography-display text-white">厳選した制作実績</h1>
+            <p className="mt-6 typography-body text-zinc-300">
               家具、ゲーミング、ライフスタイル、オンデマンドサービスなど、多彩なブランドのUI/UX体験をデザイン・開発してきました。
             </p>
           </div>
@@ -60,15 +60,15 @@ const ProjectCard = ({ project, locale, index }: ProjectCardProps) => {
                 <LazyImage src={project.logo} className="h-8 w-8 object-contain" alt={`${project.cardTitle} logo`} />
               </div>
               <div>
-                <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">{copy.role}</p>
-                <h2 className="mt-1 text-2xl font-semibold text-white sm:text-3xl">{project.cardTitle}</h2>
+                <p className="typography-meta text-zinc-500">{copy.role}</p>
+                <h2 className="mt-1 typography-subheading text-white">{project.cardTitle}</h2>
               </div>
             </div>
-            <span className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-100">
+            <span className="rounded-full border border-white/20 px-4 py-2 typography-meta text-zinc-100">
               {copy.date}
             </span>
           </div>
-          <p className="text-base leading-relaxed text-zinc-300">{copy.summary}</p>
+          <p className="typography-body text-zinc-300">{copy.summary}</p>
           {project.gallery.length ? (
             <div className="flex gap-4 overflow-x-auto pb-2">
               {project.gallery.map((image, galleryIndex) => (
@@ -87,7 +87,7 @@ const ProjectCard = ({ project, locale, index }: ProjectCardProps) => {
           ) : null}
           <AppLink
             href={href}
-            className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:border-white"
+            className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 typography-button text-white transition hover:-translate-y-0.5 hover:border-white"
           >
             {`${project.cardTitle} を詳しく見る`}
           </AppLink>

--- a/pages/portfolio/index.tsx
+++ b/pages/portfolio/index.tsx
@@ -16,8 +16,8 @@ const PortfolioListPage = () => {
         <div className="pointer-events-none absolute inset-x-0 top-0 h-72 bg-gradient-to-b from-sky-400/10 via-transparent to-transparent blur-3xl" />
         <div className="layout-container">
           <div className="max-w-3xl">
-            <h1 className="text-4xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-5xl">Selected Portfolio</h1>
-            <p className="mt-6 text-lg text-zinc-600 transition-colors duration-300 dark:text-zinc-300">
+            <h1 className="typography-display text-zinc-900 transition-colors duration-300 dark:text-white">Selected Portfolio</h1>
+            <p className="mt-6 typography-body text-zinc-600 transition-colors duration-300 dark:text-zinc-300">
               A collection of crafted UI/UX journeys built for brands spanning furniture, gaming, lifestyle, and on-demand services.
             </p>
           </div>
@@ -55,20 +55,20 @@ const ProjectCard = ({ project, locale, index }: ProjectCardProps) => {
       <div className="relative grid gap-10 rounded-[2.5rem] border border-zinc-200/80 bg-white/90 p-8 backdrop-blur-xl transition-colors duration-300 dark:border-white/10 dark:bg-black/60 lg:grid-cols-[1.15fr_0.85fr]">
         <div className="space-y-6">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-center gap-4">
-              <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-zinc-200/70 bg-white/80 transition-colors duration-300 dark:border-white/10 dark:bg-white/10">
-                <LazyImage src={project.logo} className="h-8 w-8 object-contain" alt={`${project.cardTitle} logo`} />
+              <div className="flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-zinc-200/70 bg-white/80 transition-colors duration-300 dark:border-white/10 dark:bg-white/10">
+                  <LazyImage src={project.logo} className="h-8 w-8 object-contain" alt={`${project.cardTitle} logo`} />
+                </div>
+                <div>
+                  <p className="typography-meta text-zinc-500 transition-colors duration-300 dark:text-zinc-400">{copy.role}</p>
+                  <h2 className="mt-1 typography-subheading text-zinc-900 transition-colors duration-300 dark:text-white">{project.cardTitle}</h2>
+                </div>
               </div>
-              <div>
-                <p className="text-xs uppercase tracking-[0.35em] text-zinc-500">{copy.role}</p>
-                <h2 className="mt-1 text-2xl font-semibold text-zinc-900 transition-colors duration-300 dark:text-white sm:text-3xl">{project.cardTitle}</h2>
-              </div>
-            </div>
-            <span className="rounded-full border border-zinc-200/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-700 transition-colors duration-300 dark:border-white/20 dark:text-zinc-100">
+            <span className="rounded-full border border-zinc-200/70 px-4 py-2 typography-meta text-zinc-700 transition-colors duration-300 dark:border-white/20 dark:text-zinc-100">
               {copy.date}
             </span>
           </div>
-          <p className="text-base leading-relaxed text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{copy.summary}</p>
+          <p className="typography-body text-zinc-600 transition-colors duration-300 dark:text-zinc-300">{copy.summary}</p>
           {project.gallery.length ? (
             <div className="flex gap-4 overflow-x-auto pb-2">
               {project.gallery.map((image, galleryIndex) => (
@@ -87,7 +87,7 @@ const ProjectCard = ({ project, locale, index }: ProjectCardProps) => {
           ) : null}
           <AppLink
             href={href}
-            className="inline-flex items-center justify-center rounded-full border border-zinc-200/70 px-6 py-3 text-sm font-semibold text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:text-zinc-900 dark:border-white/20 dark:text-white dark:hover:border-white"
+            className="inline-flex items-center justify-center rounded-full border border-zinc-200/70 px-6 py-3 typography-button text-zinc-800 transition hover:-translate-y-0.5 hover:border-zinc-900 hover:text-zinc-900 dark:border-white/20 dark:text-white dark:hover:border-white"
           >
             View Case Study
           </AppLink>

--- a/styles/style.css
+++ b/styles/style.css
@@ -68,6 +68,25 @@
   --container-inline: var(--space-6);
   --container-inline-narrow: var(--space-6);
   --container-inline-tight: var(--space-6);
+
+  --font-size-display: clamp(2.75rem, 1.8rem + 3vw, 3.75rem);
+  --font-size-heading: clamp(2.125rem, 1.4rem + 2vw, 2.75rem);
+  --font-size-subheading: clamp(1.625rem, 1.2rem + 1.2vw, 2.125rem);
+  --font-size-body-lg: clamp(1.125rem, 1.05rem + 0.4vw, 1.25rem);
+  --font-size-body: clamp(1rem, 0.96rem + 0.25vw, 1.125rem);
+  --font-size-body-sm: 0.95rem;
+  --font-size-button: 0.95rem;
+  --font-size-eyebrow: 0.875rem;
+  --font-size-meta: 0.75rem;
+
+  --line-height-tight: 1.1;
+  --line-height-snug: 1.3;
+  --line-height-relaxed: 1.6;
+
+  --tracking-tight: -0.02em;
+  --tracking-heading: -0.015em;
+  --tracking-eyebrow: 0.35em;
+  --tracking-meta: 0.4em;
 }
 
 @media (min-width: 640px) {
@@ -216,6 +235,64 @@
   .lazy[data-ll-status='loaded'],
   .lazy[data-ll-status='applied'] {
     opacity: 1;
+  }
+
+  .typography-display {
+    font-size: var(--font-size-display);
+    line-height: var(--line-height-tight);
+    letter-spacing: var(--tracking-tight);
+    @apply font-semibold;
+  }
+
+  .typography-heading {
+    font-size: var(--font-size-heading);
+    line-height: var(--line-height-snug);
+    letter-spacing: var(--tracking-heading);
+    @apply font-semibold;
+  }
+
+  .typography-subheading {
+    font-size: var(--font-size-subheading);
+    line-height: var(--line-height-snug);
+    letter-spacing: var(--tracking-heading);
+    @apply font-semibold;
+  }
+
+  .typography-body-lg {
+    font-size: var(--font-size-body-lg);
+    line-height: var(--line-height-relaxed);
+  }
+
+  .typography-body {
+    font-size: var(--font-size-body);
+    line-height: var(--line-height-relaxed);
+  }
+
+  .typography-body-sm {
+    font-size: var(--font-size-body-sm);
+    line-height: var(--line-height-relaxed);
+  }
+
+  .typography-button {
+    font-size: var(--font-size-button);
+    line-height: 1.25;
+    @apply font-semibold;
+  }
+
+  .typography-eyebrow {
+    font-size: var(--font-size-eyebrow);
+    letter-spacing: var(--tracking-eyebrow);
+    line-height: 1.2;
+    text-transform: uppercase;
+    @apply font-semibold;
+  }
+
+  .typography-meta {
+    font-size: var(--font-size-meta);
+    letter-spacing: var(--tracking-meta);
+    line-height: 1.2;
+    text-transform: uppercase;
+    @apply font-semibold;
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared typography variables and helper classes to centralize the type scale
- refactor hero, section, navigation, and card components to use the new typography system
- align English and Japanese portfolio pages with the standardized typography treatment

## Testing
- yarn lint *(fails: package missing from lockfile in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d77fd8db30832695078af63aa31cdb