### PR TITLE
Fix GitHub Pages workflow to use yarn

### DIFF
--- a/.github/workflows/jiasheng-deploy.yml
+++ b/.github/workflows/jiasheng-deploy.yml
@@ -16,19 +16,20 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build
-    - run: npm run export
+        cache: 'yarn'
+        cache-dependency-path: yarn.lock
+    - run: yarn install --frozen-lockfile
+    - run: yarn build
+    - run: yarn export
     - run: touch ./out/.nojekyll
     
     - name: Deploy New 🚀

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "export": "next export"
   },
   "dependencies": {
     "next": "14.2.4",


### PR DESCRIPTION
## Summary
- update the deployment workflow to run on Node.js 18 with Yarn caching and commands
- add a Next.js export script so the workflow can statically export the site

## Testing
- `yarn install --frozen-lockfile` *(fails: registry returned 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d783daf3548326be6987cdbd470c63