### PR TITLE
Configure Next.js static export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const repoBasePath = '/jiasheng98.github.io';
 const isProd = process.env.NODE_ENV === 'production';
 
 const nextConfig = {
+  output: 'export',
   ...(isProd
     ? {
         basePath: repoBasePath,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "export": "next export"
+    "export": "next build"
   },
   "dependencies": {
     "next": "14.2.4",


### PR DESCRIPTION
## Summary
- configure Next.js 14 to emit static output by setting `output: 'export'`
- update the `export` npm script to call `next build` for the new export flow

## Testing
- npm run export *(fails in the container because TypeScript packages are unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_68d785073a388326aef793271ab072c4