### PR TITLE
Fix base path handling for GitHub Pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,14 @@
 /** @type {import('next').NextConfig} */
-const repoBasePath = '/jiasheng98.github.io';
+const repoName = process.env.GITHUB_REPOSITORY?.split('/')?.[1] ?? '';
+const isProjectPageRepo = Boolean(repoName && !repoName.endsWith('.github.io'));
 const isProd = process.env.NODE_ENV === 'production';
 
 const nextConfig = {
   output: 'export',
-  ...(isProd
+  ...(isProd && isProjectPageRepo
     ? {
-        basePath: repoBasePath,
-        assetPrefix: repoBasePath
+        basePath: `/${repoName}`,
+        assetPrefix: `/${repoName}`
       }
     : {}),
   poweredByHeader: false,


### PR DESCRIPTION
## Summary
- detect whether the repository is a project page before applying a base path and asset prefix
- avoid forcing the GitHub Pages user site to load assets from a non-existent subdirectory

## Testing
- not run (network-restricted environment prevents installing dependencies)


------
https://chatgpt.com/codex/tasks/task_b_68d786e7890c83269d57bc0c1d6a93ce