### PR TITLE
Fix GitHub Pages asset loading errors

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,19 @@
 /** @type {import('next').NextConfig} */
-const repoBasePath = '/jiasheng98.github.io';
+const rawRepoBasePath = process.env.NEXT_PUBLIC_BASE_PATH?.trim();
+const normalizedRepoBasePath = rawRepoBasePath
+  ? rawRepoBasePath.startsWith('/')
+    ? rawRepoBasePath
+    : `/${rawRepoBasePath}`
+  : undefined;
 const isProd = process.env.NODE_ENV === 'production';
+const hasRepoBasePath = Boolean(normalizedRepoBasePath);
 
 const nextConfig = {
   output: 'export',
-  ...(isProd
+  ...(isProd && hasRepoBasePath
     ? {
-        basePath: repoBasePath,
-        assetPrefix: repoBasePath
+        basePath: normalizedRepoBasePath,
+        assetPrefix: normalizedRepoBasePath
       }
     : {}),
   poweredByHeader: false,

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Jia Sheng Portfolio",
+  "short_name": "JiaSheng",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "description": "Personal portfolio site for Jia Sheng.",
+  "icons": [
+    {
+      "src": "/Logo.png",
+      "type": "image/png",
+      "sizes": "512x512"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- make the GitHub Pages base path configurable so production builds work on user sites
- add a `site.webmanifest` file so the manifest request no longer 404s

## Testing
- yarn lint *(fails: workspace package is missing from the lockfile in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d787773c588326b1206490fbf5b34e